### PR TITLE
Adding Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a problem or unexpected behavior
+title: "[BUG]"
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS: [e.g. Windows, macOS, Linux]
+- Browser (if applicable): [e.g. Chrome, Firefox]
+- Version: [e.g. 1.0.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an idea for improvement or a new feature
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+---
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Problem / Use Case**
+Explain the problem this feature solves or why it would be useful.
+
+**Alternatives considered**
+List any alternative solutions or features you considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## Issue PR Solves
Previously, contributors did not have a standardized format to describe issues, which sometimes led to incomplete or unclear reports.

## Description
This PR adds issue templates for both **bug reports** and **feature requests**, providing a consistent structure for users to submit their issues. With these templates, contributors can provide all the necessary information in a clear and organized way, making it easier for maintainers to understand, prioritize, and resolve issues efficiently.


## Issue it closes
Closes #79 

## Screenshot to display changes made
<img width="841" height="301" alt="image" src="https://github.com/user-attachments/assets/fc3ce178-ab4f-486b-bb2b-c418faf44b89" />

- [x] Attached proof of work
- [x] Code is working as intended
- [x] PR closes Issue #79 
- [x] No conflicts
- [x] No new bugs or errors